### PR TITLE
Fix RoBERTa pivot table

### DIFF
--- a/analysis_scripts/bbq_calculate_bias_score.py
+++ b/analysis_scripts/bbq_calculate_bias_score.py
@@ -63,7 +63,8 @@ def load_roberta_results(csv_path: str) -> pd.DataFrame:
     df = pd.read_csv(csv_path)
     df["max_ans"] = df[["ans0", "ans1", "ans2"]].astype(float).idxmax(axis=1)
     df = df.drop(columns=["ans0", "ans1", "ans2"])
-    df = df.pivot_table(index=["index", "cat"], columns="model", values="max_ans").reset_index()
+    # pivot so that we have one column per model; using 'first' preserves string labels
+    df = df.pivot_table(index=["index", "cat"], columns="model", values="max_ans", aggfunc="first").reset_index()
     df = df.rename(columns={"index": "example_id", "cat": "category"})
     return df
 


### PR DESCRIPTION
## Summary
- preserve string labels when loading RoBERTa results

## Testing
- `python -m py_compile analysis_scripts/bbq_calculate_bias_score.py`


------
https://chatgpt.com/codex/tasks/task_e_687d416ee7e48327b45bdada186db903